### PR TITLE
fix: reset FlagIcon to previous implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zonos/amino",
-  "version": "5.5.17",
+  "version": "5.5.18",
   "description": "Core UI components for Amino",
   "repository": "git@github.com:Zonos/amino.git",
   "license": "MIT",

--- a/src/icons/flag-icon/FlagIcon.tsx
+++ b/src/icons/flag-icon/FlagIcon.tsx
@@ -1,49 +1,28 @@
-import { forwardRef, lazy, Suspense } from 'react';
+import { forwardRef } from 'react';
 
-import type * as flags from 'src/icons/flags/_FlagIndex';
-import { Default } from 'src/icons/flags/Default';
+import * as flags from 'src/icons/flags/_FlagIndex';
 
 export type Flag = keyof typeof flags;
 export type FlagScale = 'small' | 'medium' | 'large';
-
 export type FlagIconProps = { iconScale: FlagScale } & {
   code: Flag;
 };
 
 export const FlagIcon = forwardRef<SVGSVGElement, FlagIconProps>(
   ({ code, iconScale }, ref) => {
-    const flagSizeProps = () => {
-      switch (iconScale) {
-        case 'small':
-          return { height: 16, width: 16 };
-        case 'medium':
-          return { height: 20, width: 20 };
-        case 'large':
-        default:
-          return { borderRadius: 11, height: 32, width: 32 };
-      }
-    };
+    const Icon = flags[code];
+    // The props sometimes need to get typecast upstream, so we need to check
+    if (!Icon) {
+      return null;
+    }
 
-    const renderIcon = () => {
-      const Icon = lazy(() =>
-        // This exact string format is necessary to be used by the build script plugin for replacing dynamic imports
-        import(`src/icons/flags/` + code + `.tsx`).then(module => ({
-          default: module[code],
-        })),
-      );
+    if (iconScale === 'small') {
+      return <Icon ref={ref} height={16} width={16} />;
+    }
+    if (iconScale === 'medium') {
+      return <Icon ref={ref} height={20} width={20} />;
+    }
 
-      // The props sometimes need to get typecast upstream, so we need to check
-      if (!Icon) {
-        return null;
-      }
-
-      return <Icon ref={ref} {...flagSizeProps()} />;
-    };
-
-    return (
-      <Suspense fallback={<Default {...flagSizeProps()} />}>
-        {renderIcon()}
-      </Suspense>
-    );
+    return <Icon ref={ref} borderRadius={11} height={32} width={32} />;
   },
 );


### PR DESCRIPTION
## Linear issue

<!-- Example:
[Update Catalog CSV import to support multiple HS codes per item](https://linear.app/zonos/issue/FE-730/update-catalog-csv-import-to-support-multiple-hs-codes-per-item)
-->

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR reverts the FlagIcon implementation to its previous version. The current lazy/Suspense implementation is causing flickering and rendering loops in Dashboard

## Todo

- [ ] Bump version and add tag
