### PR TITLE
fix: make FilterSelect searchable

### DIFF
--- a/src/components/filter/filter-select/FilterSelect.tsx
+++ b/src/components/filter/filter-select/FilterSelect.tsx
@@ -120,6 +120,7 @@ export const FilterSelect = <
   return renderWrapper(
     <Select
       isClearable={false}
+      isSearchable
       onChange={o => setEditingValue(o?.value || null)}
       onKeyDown={handleKeyDown}
       onMenuClose={() => setMenuOpen(false)}


### PR DESCRIPTION
## Linear issue
<img width="523" alt="Screenshot 2025-03-26 at 11 18 10 AM" src="https://github.com/user-attachments/assets/a790fec5-77e2-46ae-bcfb-f05475eacce5" />


## Preview
<https://nick.amino.zonos.com/?path=/story/amino-filters--country-select>
Select should be searchable

## Description

<!-- Explain what this Pull Request should do -->
<!-- Example:
This PR fixes a bug in our elastic search order query.
-->

This PR makes the FilterSelect searchable for easier use.

## Todo

- [ ] Bump version and add tag
